### PR TITLE
Display error messages

### DIFF
--- a/src/billingo.js
+++ b/src/billingo.js
@@ -74,7 +74,7 @@ class Billingo {
     } catch (err) {
       throw new Error(`Not parsable body ${response.body}`)
     }
-    if (body.success) return body.data
+    if (body.success === 'true' || body.success === true) return body.data
     if (body.error) throw new Error(body.error)
     if (body.errors) {
       var error = new Error(`ValidationError via ${route} ${JSON.stringify(body.errors)}`)


### PR DESCRIPTION
When the response contained body.success === 'false', body.success evaluated to true, causing the request to fail silently.